### PR TITLE
Uppercase H vs lowercase fix for "theHarvester"

### DIFF
--- a/sniper
+++ b/sniper
@@ -79,10 +79,10 @@ if [ $SCAN_TYPE == "DOMAIN" ];
 then
 	dig -x $TARGET
 	whois $TARGET
-	theharvester -d $TARGET -b google
-	theharvester -d $TARGET -b bing
-	theharvester -d $TARGET -b linkedin
-	theharvester -d $TARGET -b people123
+	theHarvester -d $TARGET -b google
+	theHarvester -d $TARGET -b bing
+	theHarvester -d $TARGET -b linkedin
+	theHarvester -d $TARGET -b people123
 	dnsrecon -d $TARGET
 	dnsrecon -d $TARGET -t zonewalk
 	dnsrecon -d quora.com -t axfr


### PR DESCRIPTION
Kali refers to "theharvester" as "theHarvester" with a capital "H". Should fix that part of issue #20 , the rest he needs to update via install.sh